### PR TITLE
New syntax for gh-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A github-cli extension script to clone all repositories in an organization, opti
 ## Installation
 
 ```bash
-gh extension install matt-bartel/gh-clone-org
+gh extension install https://github.com/matt-bartel/gh-clone-org
 ```
 
 ## Usage


### PR DESCRIPTION
The original instructions gave an error: 
$> gh extension install matt-bartel/gh-clone-org
extension is not installable: missing executable

When I use the full url, it works
$> gh extension install https://github.com/matt-bartel/gh-clone-org
✓ Installed extension https://github.com/matt-bartel/gh-clone-org
