### PR TITLE
Canonicalize the name of the org to eliminate casing issues

### DIFF
--- a/gh-clone-org
+++ b/gh-clone-org
@@ -147,7 +147,7 @@ cd "$CLONE_PATH"
 set +e
 for repo in $REPOS
 do
-  d=${repo#$GITHUB_ORG/}
+  d=${repo#*/}
   if [ -d "$d" ]
   then
     echo "'$d' already exists, attempting to checkout the default branch and pull"


### PR DESCRIPTION
The logic for stripping the org prefix from the repo list won't handle casing differences, but the API does. With incorrect org/user casing, `gh repo clone` will handle a casing difference and clone the repo, but then subsequent runs will fail to strip the org name when testing `-d` and attempt to clone, which will error.

This PR replaces the user-provided org name with that from the `users` API, which will match the casing of the `repos` API, and the directory existence test should work regardless of user input.

There are many alternative ways to approach this and we can discuss/switch to one of them if you'd prefer.