### PR TITLE
Make script faster with shallow cloning and parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ A github-cli extension script to clone all repositories in an organization, opti
 gh extension install matt-bartel/gh-clone-org
 ```
 
+The script will attempt to use `parallel` if it is available, otherwise it will clone repositories one at a time. To install `parallel` on macOS:
+
+```bash
+brew install parallel
+```
+
 ## Usage
 
 ```txt
@@ -28,6 +34,8 @@ gh clone-org [-t TOPIC] [-s QUERY] [-p PATH] [-y] ORG
     See: https://docs.github.com/en/github/searching-for-information-on-github/searching-on-github/searching-for-repositories
   -n, --dry-run
     Do not actually clone, just show what would be cloned
+  -1, --single-threaded
+    Clone one repository at a time, instead of in parallel.
   -h, --help
     Display this message.
 ```

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ gh clone-org [-t TOPIC] [-s QUERY] [-p PATH] [-y] ORG
     Clone path. Default: current directory.
   -t, --topic TOPIC
     Clone repositories with this topic
+  -S, --shallow
+    Clone repositories with --depth 1
   -s --search QUERY
     Clone repositories found by this search string. If this is provided '-t' will be ignored.
     Example: -s "is:public language:go"

--- a/gh-clone-org
+++ b/gh-clone-org
@@ -21,6 +21,8 @@ usage()
   echo "    See: https://docs.github.com/en/github/searching-for-information-on-github/searching-on-github/searching-for-repositories"
   echo "  -n, --dry-run"
   echo "    Do not actually clone, just show what would be cloned"
+  echo "  -1, --single-threaded"
+  echo "    Clone one repository at a time, instead of in parallel."
   echo "  -h, --help"
   echo "    Display this message."
 }
@@ -67,6 +69,8 @@ do
       SEARCH="$1"
       ;;
     -n | --dry-run) DRY_RUN="true"
+      ;;
+    -1 | --single-threaded) SINGLE="true"
       ;;
     -h | --help ) usage
       exit
@@ -151,10 +155,9 @@ fi
 mkdir -p "$CLONE_PATH"
 cd "$CLONE_PATH"
 
-set +e
-for repo in $REPOS
-do
-  d=${repo#*/}
+clone_or_update() {
+  local -r repo="$1"
+  local -r d=${repo#*/}
   if [ -d "$d" ]
   then
     echo "'$d' already exists, attempting to checkout the default branch and pull"
@@ -165,4 +168,16 @@ do
   else
     gh repo clone "$repo" -- "${GIT_CLONE_ARGS[@]}"
   fi
-done
+}
+export -f clone_or_update
+
+set +e
+if command -v parallel &> /dev/null && [ "$SINGLE" != "true" ]
+then
+  echo "$REPOS" | parallel -j 10 --bar clone_or_update
+else
+  for repo in $REPOS
+  do
+    clone_or_update "$repo"
+  done
+fi

--- a/gh-clone-org
+++ b/gh-clone-org
@@ -13,6 +13,8 @@ usage()
   echo "    Clone path. Default: current directory."
   echo "  -t, --topic TOPIC"
   echo "    Clone repositories with this topic"
+  echo "  -S, --shallow"
+  echo "    Clone repositories with --depth 1"
   echo "  -s --search QUERY"
   echo "    Clone repositories found by this search string. If this is provided '-t' will be ignored."
   echo "    Example: -s \"is:public language:go\""
@@ -42,6 +44,9 @@ urlencode() {
   LC_COLLATE=$old_lc_collate
 }
 
+GIT_PULL_ARGS=()
+GIT_CLONE_ARGS=()
+
 while [ "$1" != "" ]
 do
   case $1 in
@@ -55,6 +60,8 @@ do
       ;;
     -p | --path ) shift
       CLONE_PATH="$1"
+      ;;
+    -S | --shallow ) GIT_CLONE_ARGS+=("--depth=1") GIT_PULL_ARGS+=("--depth=1")
       ;;
     -s | --search ) shift
       SEARCH="$1"
@@ -153,9 +160,9 @@ do
     echo "'$d' already exists, attempting to checkout the default branch and pull"
     cd "$d"
     default_branch="$(gh api "repos/$repo" -q '.default_branch')"
-    git checkout "$default_branch" && git pull
+    git checkout "$default_branch" && git pull "${GIT_PULL_ARGS[@]}"
     cd ..
   else
-    gh repo clone "$repo"
+    gh repo clone "$repo" -- "${GIT_CLONE_ARGS[@]}"
   fi
 done


### PR DESCRIPTION
This script is quite slow for my organization, which has ~2k repositories.

This PR has two changes that speed it up significantly:

1. Add an option to shallow-clone repositories. Most of the time, I want to
   clone the org so I can learn things about the current state, and I don't need
   the whole history. This significantly decreases time to clone, and disk space
   used. I don't know if this is the most common use case, so I made it opt-in.
   Happy to change this to being the default if you want.

2. Use GNU parallel if it's available. I haven't had issues with `-j 10` on my
   machine (I have a similar script that uses this), but I'm happy to change it
   to something configurable if you want. This gives around a 10x speedup.

I have various other potential improvements in mind, that I use in my own
script, but I wanted to get your feedback on these first. Thank you for
maintaining this script!
